### PR TITLE
Updated deprecated iOS8 notification register method

### DIFF
--- a/src/ios/CDVParsePlugin.m
+++ b/src/ios/CDVParsePlugin.m
@@ -58,10 +58,11 @@
         [[UIApplication sharedApplication] registerForRemoteNotifications];
     }
     else {
-        [[UIApplication sharedApplication] registerForRemoteNotificationTypes:
-            UIRemoteNotificationTypeBadge |
-            UIRemoteNotificationTypeAlert |
-            UIRemoteNotificationTypeSound];
+        [[UIApplication sharedApplication] registerUserNotificationSettings:
+            [UIUserNotificationSettings settingsForTypes:
+            (UIUserNotificationTypeSound |
+            UIUserNotificationTypeAlert |
+            UIUserNotificationTypeBadge) categories:nil]];
     }
 
     CDVPluginResult* pluginResult = nil;


### PR DESCRIPTION
Based on information found in http://stackoverflow.com/questions/29674222/registering-for-parse-notifications-ios7-and-ios8-compiler-warnings
